### PR TITLE
Block comments from Dutch websites

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -516,6 +516,13 @@ div.comments-bar,
 /* Dailymotion */
 .pl_video_comment_post_and_comments,
 
+/* 
+ * nu.nl and other Dutch websites that use the 'reacties' and 'reactieContainer' class
+*/
+.reacties, /* nu.nl */
+.reactieContainer, /* tweakers.net */
+
+
 /* ...misc... */
 
 #commentlist,


### PR DESCRIPTION
I added a few general classes to block comments on Dutch websites.

The `reacties` and `reactieContainer` CSS classes have been blocked. 
These classes would literally translate to `reactions` and `reactionContainer` respectively. 

Can this be merged so that I can finally have peace on Dutch websites?
